### PR TITLE
Update tests for funs

### DIFF
--- a/tests/capture.temper
+++ b/tests/capture.temper
@@ -1,11 +1,9 @@
 let { CompiledRegex } = import("std/regex");
-let { test, assert, TestFixtureBase } = import("std/testing");
+let { assert } = import("std/testing");
 let { compile } = import("../regex.temper");
 
-export class SimpleCaptureTest {
-  @test public testCapture(): Void | NoResult {
-    let regex = compile("(?cent=\\d)(?tens=\\d)(?ones=\\d)");
-    let tens = regex.find("123")["tens"].value;
-    assert(tens == "2") { "Expected 2, not: ${tens}" }
-  }
+@test let testCapture(): Void | NoResult {
+  let regex = compile("(?cent=\\d)(?tens=\\d)(?ones=\\d)");
+  let tens = regex.find("123")["tens"].value;
+  assert(tens == "2") { "Expected 2, not: ${tens}" }
 }

--- a/tests/error.temper
+++ b/tests/error.temper
@@ -1,29 +1,27 @@
 let { CompiledRegex } = import("std/regex");
-let { test, assert, TestFixtureBase } = import("std/testing");
+let { assert } = import("std/testing");
 let { compile } = import("../regex.temper");
 
-export class ErrorTest {
-  @test public ok(): Void {
-    // Verify that the infrastructure works.
-    // Usually, we'll be checking for errors in this file.
-    // TODO Remove explicit `void` result if we can adjust java codegen.
-    assert(hasResult { compile("ok"); }) { "expected result" }
-  }
+@test let ok(): Void {
+  // Verify that the infrastructure works.
+  // Usually, we'll be checking for errors in this file.
+  // TODO Remove explicit `void` result if we can adjust java codegen.
+  assert(hasResult { compile("ok"); }) { "expected result" }
+}
 
-  @test public unclosedCapture(): Void {
-    // TODO Remove explicit `void` result if we can adjust java codegen.
-    assertNoResult { compile("(unclosed"); }
-  }
+@test let unclosedCapture(): Void {
+  // TODO Remove explicit `void` result if we can adjust java codegen.
+  assertNoResult { compile("(unclosed"); }
+}
 
-  @test public unclosedCodePointGroup(): Void {
-    assertNoResult { compile("[group-unclosed"); }
-  }
+@test let unclosedCodePointGroup(): Void {
+  assertNoResult { compile("[group-unclosed"); }
+}
 
-  @test public unclosedNamedCaptureName(): Void {
-    assertNoResult { compile("(?name"); }
-    assertNoResult { compile("(?name="); }
-    assertNoResult { compile("(?"); }
-  }
+@test let unclosedNamedCaptureName(): Void {
+  assertNoResult { compile("(?name"); }
+  assertNoResult { compile("(?name="); }
+  assertNoResult { compile("(?"); }
 }
 
 let assertNoResult(action: fn(): Void | NoResult): Void {

--- a/tests/escape.temper
+++ b/tests/escape.temper
@@ -1,46 +1,44 @@
 let { CompiledRegex } = import("std/regex");
-let { test, assert, TestFixtureBase } = import("std/testing");
+let { assert } = import("std/testing");
 let { compile } = import("../regex.temper");
 
-export class SimpleIdTest {
-  @test public testEscapedDot(): Void | NoResult {
-    let regex = compile("\\.\\w+");
-    let expected = ".net";
-    let id = regex.find("the ${expected} runtime")["full"].value;
+@test let testEscapedDot(): Void | NoResult {
+  let regex = compile("\\.\\w+");
+  let expected = ".net";
+  let id = regex.find("the ${expected} runtime")["full"].value;
+  assert(id == expected) { "Expected ${expected}, not: ${id}" }
+}
+
+@test let testEscapedParens(): Void | NoResult {
+  let regex = compile("\\(?\\d\\d\\d\\)? (?mid=867) (?last=5309)");
+  let expected = "(570) 867 5309";
+  let id = regex.find("the numbers 867 5309 are not actually used in any phone number due a *certain* song, like ${expected}")["full"].value;
+  assert(id == expected) { "Expected ${expected}, not: ${id}" }
+}
+
+@test let testEscapedSquareBrace(): Void | NoResult {
+  let regex = compile("\\[[yn]\\]");
+  do {
+    let expected = "[y]";
+    let id = regex.find("continue (y/n): ${expected}")["full"].value;
     assert(id == expected) { "Expected ${expected}, not: ${id}" }
   }
-
-  @test public testEscapedParens(): Void | NoResult {
-    let regex = compile("\\(?\\d\\d\\d\\)? (?mid=867) (?last=5309)");
-    let expected = "(570) 867 5309";
-    let id = regex.find("the numbers 867 5309 are not actually used in any phone number due a *certain* song, like ${expected}")["full"].value;
+  do {
+    let expected = "[n]";
+    let id = regex.find("use empty password: ${expected}")["full"].value;
     assert(id == expected) { "Expected ${expected}, not: ${id}" }
   }
+}
 
-  @test public testEscapedSquareBrace(): Void | NoResult {
-    let regex = compile("\\[[yn]\\]");
-    do {
-      let expected = "[y]";
-      let id = regex.find("continue (y/n): ${expected}")["full"].value;
-      assert(id == expected) { "Expected ${expected}, not: ${id}" }
-    }
-    do {
-      let expected = "[n]";
-      let id = regex.find("use empty password: ${expected}")["full"].value;
-      assert(id == expected) { "Expected ${expected}, not: ${id}" }
-    }
-  }
+@test let testEscpaedCurlyBraces(): Void | NoResult {
+  let regex = compile(":\\}");
+  let expected = ":}";
+  let id = regex.find("when i write temper i feel like smiling ${expected}")["full"].value;
+  assert(id == expected) { "Expected ${expected}, not: ${id}" }
+}
 
-  @test public testEscpaedCurlyBraces(): Void | NoResult {
-    let regex = compile(":\\}");
-    let expected = ":}";
-    let id = regex.find("when i write temper i feel like smiling ${expected}")["full"].value;
-    assert(id == expected) { "Expected ${expected}, not: ${id}" }
-  }
-
-  @test public testEscapedBackslash(): Void | NoResult {
-    let regex = compile("\\\\");
-    let expected = "\\";
-    let id = regex.find("playing dominoes... ||||${expected}")["full"].value;
-  }
+@test let testEscapedBackslash(): Void | NoResult {
+  let regex = compile("\\\\");
+  let expected = "\\";
+  let id = regex.find("playing dominoes... ||||${expected}")["full"].value;
 }

--- a/tests/id.temper
+++ b/tests/id.temper
@@ -1,12 +1,10 @@
 let { CompiledRegex } = import("std/regex");
-let { test, assert, TestFixtureBase } = import("std/testing");
+let { assert } = import("std/testing");
 let { compile } = import("../regex.temper");
 
-export class SimpleIdTest {
-  @test public testId(): Void | NoResult {
-    let regex = compile("\\b[a-zA-Z_][a-zA-Z0-9_]*\\b");
-    let expected = "c_symbol1";
-    let id = regex.find("123_abc ${expected} c_symbol2")["full"].value;
-    assert(id == expected) { "Expected ${expected}, not: ${id}" }
-  }
+@test let testId(): Void | NoResult {
+  let regex = compile("\\b[a-zA-Z_][a-zA-Z0-9_]*\\b");
+  let expected = "c_symbol1";
+  let id = regex.find("123_abc ${expected} c_symbol2")["full"].value;
+  assert(id == expected) { "Expected ${expected}, not: ${id}" }
 }

--- a/tests/sub.temper
+++ b/tests/sub.temper
@@ -1,5 +1,5 @@
 let { CompiledRegex, Group } = import("std/regex");
-let { test, assert, TestFixtureBase } = import("std/testing");
+let { assert } = import("std/testing");
 let { compileWith, sub } = import("../regex.temper");
 
 let run(regex: CompiledRegex): Void {
@@ -13,13 +13,11 @@ let run(regex: CompiledRegex): Void {
   check("last", expected = "Summa");
 }
 
-export class SubTest {
-  @test public testSub(): Void | NoResult {
-    let regex = compileWith(
-      "(?first=(?$Word)) (?last=(?$Word))",
-      [ "Word" ],
-      [ sub("\\b\\w+\\b") ],
-    );
-    run(regex);
-  }
+@test let testSub(): Void | NoResult {
+  let regex = compileWith(
+    "(?first=(?$Word)) (?last=(?$Word))",
+    [ "Word" ],
+    [ sub("\\b\\w+\\b") ],
+  );
+  run(regex);
 }

--- a/tests/variations.temper
+++ b/tests/variations.temper
@@ -1,5 +1,5 @@
 let { CodePoints, CompiledRegex } = import("std/regex");
-let { test, assert, TestFixtureBase } = import("std/testing");
+let { assert } = import("std/testing");
 let { compile, compileWith, sub, subWith } = import("../regex.temper");
 
 let checkValue(value: String, expected: String): Void {
@@ -15,52 +15,50 @@ let check(re: CompiledRegex): Void {
   checkValue(re.find("functions")["full"].value, expected = "f");
 }
 
-export class VariationsTest {
-  @test public testCodeSet(): Void | NoResult {
-    check(compile("[abcdef]"));
-  }
+@test let testCodeSet(): Void | NoResult {
+  check(compile("[abcdef]"));
+}
 
-  @test public testOr(): Void | NoResult {
-    check(compile("a|b|c|d|e|f"));
-  }
+@test let testOr(): Void | NoResult {
+  check(compile("a|b|c|d|e|f"));
+}
 
-  @test public testCodeRange(): Void | NoResult {
-    check(compile("[a-f]"));
-  }
+@test let testCodeRange(): Void | NoResult {
+  check(compile("[a-f]"));
+}
 
-  @test public testSub(): Void | NoResult {
-    let regex = compileWith(
-      "(?$a-through-f)",
-      [
-        "a-through-f",
-      ],
-      [
-        subWith(
-          "(?$char-a)|(?$char-b)|(?$char-c)|(?$char-d)|(?$char-e)|(?$char-f)",
-          [
-            "char-a",
-            "char-b",
-            "char-c",
-            "char-d",
-            "char-e",
-            "char-f",
-          ],
-          [
-            // Make one explicit simple string just for demo.
-            new CodePoints("a"),
-            subWith(
-              "(?$char-b)",
-              [ "char-b" ],
-              [ sub("b") ]
-            ),
-            sub("(?cee=c)"),
-            sub("(d)"),
-            sub("(e|e)"),
-            sub("[f-f]"),
-          ]
-        ),
-      ]
-    );
-    check(regex);
-  }
+@test let testSub(): Void | NoResult {
+  let regex = compileWith(
+    "(?$a-through-f)",
+    [
+      "a-through-f",
+    ],
+    [
+      subWith(
+        "(?$char-a)|(?$char-b)|(?$char-c)|(?$char-d)|(?$char-e)|(?$char-f)",
+        [
+          "char-a",
+          "char-b",
+          "char-c",
+          "char-d",
+          "char-e",
+          "char-f",
+        ],
+        [
+          // Make one explicit simple string just for demo.
+          new CodePoints("a"),
+          subWith(
+            "(?$char-b)",
+            [ "char-b" ],
+            [ sub("b") ]
+          ),
+          sub("(?cee=c)"),
+          sub("(d)"),
+          sub("(e|e)"),
+          sub("[f-f]"),
+        ]
+      ),
+    ]
+  );
+  check(regex);
 }


### PR DESCRIPTION
```
> temper test -b js
Tests passed: 16 of 16
```

Current code on this PR doesn't work for interpreter testing because of not importing `test` anymore, but I'm working to remove that requirement, and interpreter testing is still a bit flaky, anyway.