### PR TITLE
Take advantage of auto eq assert values

### DIFF
--- a/tests/capture.temper
+++ b/tests/capture.temper
@@ -4,5 +4,5 @@ let { compile } = import("../regex.temper");
 test("capture") {
   let regex = compile("(?cent=\\d)(?tens=\\d)(?ones=\\d)");
   let tens = regex.find("123")["tens"].value;
-  assert(tens == "2") { "Expected 2, not: ${tens}" }
+  assert(tens == "2");
 }

--- a/tests/escape.temper
+++ b/tests/escape.temper
@@ -5,14 +5,14 @@ test("escaped dot") {
   let regex = compile("\\.\\w+");
   let expected = ".net";
   let id = regex.find("the ${expected} runtime")["full"].value;
-  assert(id == expected) { "Expected ${expected}, not: ${id}" }
+  assert(id == expected);
 }
 
 test("escaped parens") {
   let regex = compile("\\(?\\d\\d\\d\\)? (?mid=867) (?last=5309)");
   let expected = "(570) 867 5309";
   let id = regex.find("the numbers 867 5309 are not actually used in any phone number due a *certain* song, like ${expected}")["full"].value;
-  assert(id == expected) { "Expected ${expected}, not: ${id}" }
+  assert(id == expected);
 }
 
 test("escaped square brace") {
@@ -20,12 +20,12 @@ test("escaped square brace") {
   do {
     let expected = "[y]";
     let id = regex.find("continue (y/n): ${expected}")["full"].value;
-    assert(id == expected) { "Expected ${expected}, not: ${id}" }
+    assert(id == expected);
   }
   do {
     let expected = "[n]";
     let id = regex.find("use empty password: ${expected}")["full"].value;
-    assert(id == expected) { "Expected ${expected}, not: ${id}" }
+    assert(id == expected);
   }
 }
 
@@ -33,7 +33,7 @@ test("escaped curly braces") {
   let regex = compile(":\\}");
   let expected = ":}";
   let id = regex.find("when i write temper i feel like smiling ${expected}")["full"].value;
-  assert(id == expected) { "Expected ${expected}, not: ${id}" }
+  assert(id == expected);
 }
 
 test("escaped backslash") {

--- a/tests/id.temper
+++ b/tests/id.temper
@@ -5,5 +5,5 @@ test("id") {
   let regex = compile("\\b[a-zA-Z_][a-zA-Z0-9_]*\\b");
   let expected = "c_symbol1";
   let id = regex.find("123_abc ${expected} c_symbol2")["full"].value;
-  assert(id == expected) { "Expected ${expected}, not: ${id}" }
+  assert(id == expected);
 }

--- a/tests/sub.temper
+++ b/tests/sub.temper
@@ -5,7 +5,7 @@ let run(test: Test, regex: CompiledRegex): Void {
   let found = regex.find("Shaw Summa");
   let check(name: String, expected: String): Void {
     let value = found[name].value;
-    assert(value == expected) { "Unexpected: ${value}" }
+    assert(value == expected);
   }
   check("full", expected = "Shaw Summa");
   check("first", expected = "Shaw");

--- a/tests/variations.temper
+++ b/tests/variations.temper
@@ -2,7 +2,7 @@ let { CodePoints, CompiledRegex } = import("std/regex");
 let { compile, compileWith, sub, subWith } = import("../regex.temper");
 
 let checkValue(test: Test, value: String, expected: String): Void {
-  assert(value == expected) { "Expected ${expected}, not ${value}" }
+  assert(value == expected);
 }
 
 let check(test: Test, re: CompiledRegex): Void | Bubble {


### PR DESCRIPTION
We now get automatic assert messages like this:

```ts
Test failed (js): capture - expected tens == "21" not 2
Tests passed: 15 of 16
Test failed
```

So take advantage of that. That said, it's still not ideal, and I'll given example of that in place.