### PR TITLE
Update for separate full

### DIFF
--- a/tests/capture.temper
+++ b/tests/capture.temper
@@ -1,5 +1,5 @@
 test("capture") {
   let regex = compile("(?cent=\\d)(?tens=\\d)(?ones=\\d)");
-  let tens = regex.find("123")["tens"].value;
+  let tens = regex.find("123").groups["tens"].value;
   assert(tens == "2");
 }

--- a/tests/escape.temper
+++ b/tests/escape.temper
@@ -1,14 +1,14 @@
 test("escaped dot") {
   let regex = compile(raw"\.\w+");
   let expected = ".net";
-  let id = regex.find("the ${expected} runtime")["full"].value;
+  let id = regex.find("the ${expected} runtime").full.value;
   assert(id == expected);
 }
 
 test("escaped parens") {
   let regex = compile(raw"\(?\d\d\d\)? (?mid=867) (?last=5309)");
   let expected = "(570) 867 5309";
-  let id = regex.find("the numbers 867 5309 are not actually used in any phone number due a *certain* song, like ${expected}")["full"].value;
+  let id = regex.find("the numbers 867 5309 are not actually used in any phone number due a *certain* song, like ${expected}").full.value;
   assert(id == expected);
 }
 
@@ -20,12 +20,12 @@ test("escaped square brace") {
   let regex = compile(raw"\[[yn]\]");
   do {
     let expected = "[y]";
-    let id = regex.find("continue (y/n): ${expected}")["full"].value;
+    let id = regex.find("continue (y/n): ${expected}").full.value;
     assert(id == expected);
   }
   do {
     let expected = "[n]";
-    let id = regex.find("use empty password: ${expected}")["full"].value;
+    let id = regex.find("use empty password: ${expected}").full.value;
     assert(id == expected);
   }
 }
@@ -39,14 +39,14 @@ test("escape dash in square") {
 test("escaped curly braces") {
   let regex = compile(raw":\}");
   let expected = ":}";
-  let id = regex.find("when i write temper i feel like smiling ${expected}")["full"].value;
+  let id = regex.find("when i write temper i feel like smiling ${expected}").full.value;
   assert(id == expected);
 }
 
 test("escaped backslash") {
   let regex = compile("\\\\");
   let expected = "\\";
-  let id = regex.find("playing dominoes... ||||${expected}")["full"].value;
+  let id = regex.find("playing dominoes... ||||${expected}").full.value;
   assert(id == expected);
 }
 
@@ -54,6 +54,6 @@ test("escaped whitespace") {
   // The idea here is that escapes in raw form need to match actual whitespace.
   let regex = compile(raw"\r\n\t[\r\n\t]");
   let expected = "\r\n\t\t";
-  let id = regex.find("something${expected}something")["full"].value;
+  let id = regex.find("something${expected}something").full.value;
   assert(id == expected);
 }

--- a/tests/id.temper
+++ b/tests/id.temper
@@ -1,6 +1,6 @@
 test("id") {
   let regex = compile("\\b[a-zA-Z_][a-zA-Z0-9_]*\\b");
   let expected = "c_symbol1";
-  let id = regex.find("123_abc ${expected} c_symbol2")["full"].value;
+  let id = regex.find("123_abc ${expected} c_symbol2").full.value;
   assert(id == expected);
 }

--- a/tests/sub.temper
+++ b/tests/sub.temper
@@ -1,18 +1,10 @@
-let checkSub(test: Test, regex: Regex): Void {
-  let found = regex.find("Shaw Summa");
-  let check(name: String, expected: String): Void {
-    let value = found[name].value;
-    assert(value == expected);
-  }
-  check("full", expected = "Shaw Summa");
-  check("first", expected = "Shaw");
-  check("last", expected = "Summa");
-}
-
-test("sub") { (test);;
+test("sub") {
   let regex = compileWith(
     "(?first=(?$Word)) (?last=(?$Word))",
     new Map([ new Pair("Word", parse("\\b\\w+\\b")) ]),
   );
-  checkSub(test, regex);
+  let found = regex.find("Shaw Summa");
+  assert(found.full.value == "Shaw Summa");
+  assert(found.groups["first"].value == "Shaw");
+  assert(found.groups["last"].value == "Summa");
 }

--- a/tests/variations.temper
+++ b/tests/variations.temper
@@ -1,6 +1,6 @@
 let checkVariation(test: Test, re: Regex): Void | Bubble {
   let check(string: String, expected: String): Void {
-    assert(re.find(string)["full"].value == expected);
+    assert(re.find(string).full.value == expected);
   }
   check("all", expected = "a");
   check("beautify", expected = "b");


### PR DESCRIPTION
- Update for temperlang/temper-prepublic#2204
- Passes all tests on c\# & js, but misses one on lua:

```
PS C:\Users\work2\Documents\projects\temper-regex-parser> temper test -b csharp
Tests passed: 22 of 22
PS C:\Users\work2\Documents\projects\temper-regex-parser> temper test -b js
Tests passed: 22 of 22
PS C:\Users\work2\Documents\projects\temper-regex-parser> temper test -b lua
Test failed (lua): sub - stack traceback:
Tests passed: 21 of 22
Test failed
```

- But I checked on main of both this and temper-prepublic, and it also fails on the same test on lua there. It fails to find the regex for the `sub` test. So I expect it has to do with previous updates and not the latest round..
- So I recommend merging the current related PRs and solving this issue separately