### PR TITLE
Update for latest temper

### DIFF
--- a/exports.temper
+++ b/exports.temper
@@ -3,21 +3,21 @@ let { ... } = import("std/regex");
 export let compileWith(
   src: String,
   slots: Mapped<String, RegexNode>,
-): Regex | Bubble {
+): Regex throws Bubble {
   parseWith(src, slots).compiled()
 }
 
-export let compile(src: String): Regex | Bubble {
+export let compile(src: String): Regex throws Bubble {
   parse(src).compiled()
 }
 
 export let parseWith(
   src: String,
   slots: Mapped<String, RegexNode>,
-): RegexNode | Bubble {
+): RegexNode throws Bubble {
   new Parser(src, slots).readOr()
 }
 
-export let parse(src: String): RegexNode | Bubble {
+export let parse(src: String): RegexNode throws Bubble {
   new Parser(src).readOr()
 }

--- a/parser.temper
+++ b/parser.temper
@@ -2,7 +2,9 @@ let Char = Int;
 
 class Parser(
   public chars: String,
-  public slots: Mapped<String, RegexNode> = new Map([]),
+  public slots: Mapped<String, RegexNode> =
+    // Ideally, this just says `new Map([])`.
+    new Map(List.of<Pair<String, RegexNode>>()),
 ) {
   public var pos: StringIndex = String.begin;
   public errors: ListBuilder<String> = new ListBuilder<String>();
@@ -47,7 +49,7 @@ class Parser(
     matchChar(char"+") || matchChar(char"*") || matchChar(char"?")
   }
 
-  public charClassBody(): RegexNode | Bubble {
+  public charClassBody(): RegexNode throws Bubble {
     let invert = matchChar(char"^");
     let opts = new ListBuilder<CodePart>();
     while (!matchChar(char"]")) {
@@ -70,7 +72,7 @@ class Parser(
     new CodeSet(opts.toList(), invert)
   }
 
-  private charClassUnit(): CodePart | Bubble {
+  private charClassUnit(): CodePart throws Bubble {
     if (matchChar(char "\\")) {
       finishEscape() as CodePart orelse do {
         error("invalid code part");
@@ -81,14 +83,14 @@ class Parser(
     }
   }
 
-  private extractCode(codePart: CodePart): Int | Bubble {
+  private extractCode(codePart: CodePart): Int throws Bubble {
     (codePart as CodePoints).value[String.begin] orelse do {
       error("invalid range edge");
       bubble()
     }
   }
 
-  private finishEscape(): RegexNode | Bubble {
+  private finishEscape(): RegexNode throws Bubble {
     var escapeCode = peek();
     if (matchChar(char"b")) {
       WordBoundary
@@ -135,7 +137,7 @@ class Parser(
     }
   }
 
-  public readSingle(): RegexNode | Bubble {
+  public readSingle(): RegexNode throws Bubble {
     if (matchChar(char"[")) {
       charClassBody()
     } else if (matchChar(char"(")) {
@@ -222,14 +224,14 @@ class Parser(
     }
   }
 
-  public readSeq(): RegexNode | Bubble {
+  public readSeq(): RegexNode throws Bubble {
     let seq = new ListBuilder<RegexNode>();
     // Maintain a buffer for sequential code points.
     let codeBuffer = new ListBuilder<String>();
-    let popCodeBuffer(): Void | Bubble {
+    let popCodeBuffer(): Void throws Bubble {
       if (!codeBuffer.isEmpty) {
         // TODO If we add `clear` to StringBuilder, we can use that here.
-        seq.add(new CodePoints(codeBuffer.join("") { (it);; it }));
+        seq.add(new CodePoints(codeBuffer.join("") { it => it }));
         codeBuffer.clear();
       }
     }
@@ -252,7 +254,7 @@ class Parser(
     }
   }
 
-  public readOr(): RegexNode | Bubble {
+  public readOr(): RegexNode throws Bubble {
     let ors = new ListBuilder<RegexNode>();
     while (!isDone() && peek() != char")") {
       if (ors.length != 0 && !matchChar(char"|")) {

--- a/tests/error.temper
+++ b/tests/error.temper
@@ -4,25 +4,25 @@ test("ok") {
   assert(hasResult { compile("ok"); });
 }
 
-test("unclosed capture") { (test);;
+test("unclosed capture") { test =>
   assertBubble(test) { compile("(unclosed"); }
 }
 
-test("unclosed code point group") { (test);;
+test("unclosed code point group") { test =>
   assertBubble(test) { compile("[group-unclosed"); }
 }
 
-test("unclosed named capture name") { (test);;
+test("unclosed named capture name") { test =>
   assertBubble(test) { compile("(?name"); }
   assertBubble(test) { compile("(?name="); }
   assertBubble(test) { compile("(?"); }
 }
 
-let assertBubble(test: Test, action: fn(): Void | Bubble): Void {
+let assertBubble(test: Test, action: fn(): Void throws Bubble): Void {
   assert(!hasResult(action));
 }
 
-let hasResult(action: fn(): Void | Bubble): Boolean {
+let hasResult(action: fn(): Void throws Bubble): Boolean {
   do {
     action();
     true

--- a/tests/variations.temper
+++ b/tests/variations.temper
@@ -1,5 +1,5 @@
-let checkVariation(test: Test, re: Regex): Void | Bubble {
-  let check(string: String, expected: String): Void | Bubble {
+let checkVariation(test: Test, re: Regex): Void throws Bubble {
+  let check(string: String, expected: String): Void throws Bubble {
     assert(re.find(string).full.value == expected);
   }
   check("all", "a");
@@ -10,19 +10,19 @@ let checkVariation(test: Test, re: Regex): Void | Bubble {
   check("functions", "f");
 }
 
-test("code set") { (test);;
+test("code set") { test =>
   checkVariation(test, compile("[abcdef]"));
 }
 
-test("or") { (test);;
+test("or") { test =>
   checkVariation(test, compile("a|b|c|d|e|f"));
 }
 
-test("code range") { (test);;
+test("code range") { test =>
   checkVariation(test, compile("[a-f]"));
 }
 
-test("sub") { (test);;
+test("sub") { test =>
   let a: RegexNode = new CodePoints("a");
   let regex = compileWith(
     "(?$a-through-f)",


### PR DESCRIPTION
With a patch in place for be-rust to avoid latest indexmap crate, this passes tests on all current backends:

```
temper-regex-parser> temper test -b csharp -b java -b js -b lua -b py -b rust
Tests passed: 132 of 132
```